### PR TITLE
Sostituta la libreria di compilazione SASS da Ruby a Node.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,30 +43,24 @@ module.exports = function (grunt) {
 
         // Stylesheets minify
         sass: {
-            // 'destination': 'source'
             // imports and dependecies defined in the SCSS file
-            development: {
+            dev: {
                 options: {
                     style: 'expanded'
                 },
                 files: {
-                    'dev/agid-spid-enter.min.css': [
-                        'src/scss/agid-spid-enter-dev.scss'
-                    ]
+                    'dev/agid-spid-enter.min.css': 'src/scss/agid-spid-enter-dev.scss'
                 }
             },
-            production: {
+            prod: {
                 options: {
                     style: 'compressed',
                     sourcemap: 'none'
                 },
                 files: {
-                    'dist/agid-spid-enter.min.<%= pkg.version %>.css': [
-                        'src/scss/agid-spid-enter-prod.scss'
-                    ]
+                    'dist/agid-spid-enter.min.<%= pkg.version %>.css': 'src/scss/agid-spid-enter-prod.scss'
                 }
             }
-
         },
 
         // Processa i CSS prodotti da sass e aggiunge vendor prefix sulle proprietà per browser obsoleti
@@ -77,25 +71,25 @@ module.exports = function (grunt) {
                     require('autoprefixer')()
                 ]
             },
-            development: {
+            dev: {
                 options: {
                     map: true
                 },
                 src: 'dev/agid-spid-enter.min.css',
                 dest: 'dev/agid-spid-enter.min.css'
             },
-            production: {
+            prod: {
                 options: {
                     map: false
                 },
-                src: 'dist/agid-spid-enter.min.<%= pkg.version %>.css',
+                src:   'dist/agid-spid-enter.min.<%= pkg.version %>.css',
                 dest: 'dist/agid-spid-enter.min.<%= pkg.version %>.css'
             }
         },
 
         // JavaScript minify
         uglify: {
-            development: {
+            dev: {
                 options: {
                     mangle: false,
                     beautify: true,
@@ -110,7 +104,7 @@ module.exports = function (grunt) {
                     ]
                 }
             },
-            production: {
+            prod: {
                 options: {
                     mangle: true,
                     beautify: false,
@@ -189,7 +183,7 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('default', ['watch']);
-    grunt.registerTask('css', ['sass', 'postcss']);
+    grunt.registerTask('css', ['sass:dev', 'postcss:dev']);
     grunt.registerTask('js', ['uglify', 'string-replace']);
     grunt.registerTask('lint', ['stylelint', 'eslint']);
     grunt.registerTask('build', ['css', 'js']);

--- a/package.json
+++ b/package.json
@@ -1,72 +1,73 @@
 {
-  "name": "spid-smart-button",
-  "version": "1.0.0",
-  "description": "Pulsante SSO per SPID",
-  "engines": {
-    "node": ">=6.1.0"
-  },
-  "localserver": {
-    "url": "http://localhost:",
-    "port": 9090
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/italia/spid-smart-button.git"
-  },
-  "license": "BSD-3-Clause",
-  "author": {
-    "name": "Umberto Rosini",
-    "email": "rosini@agid.gov.it",
-    "url": "https://github.com/umbros"
-  },
-  "contributors": [
-    {
-      "name": "Simone Rescio",
-      "email": "info@simonerescio.it",
-      "url": "https://simonerescio.it"
+    "name": "spid-smart-button",
+    "version": "1.0.0",
+    "description": "Pulsante SSO per SPID",
+    "engines": {
+      "node": ">=6.1.0"
     },
-    {
-      "name": "Davide Porrovecchio",
-      "email": "davide.porrovecchio@agid.gov.it",
-      "url": "https://github.com/pdavide"
+    "localserver": {
+      "url": "http://localhost:",
+      "port": 9090
+    },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/italia/spid-smart-button.git"
+    },
+    "license": "BSD-3-Clause",
+    "author": {
+      "name": "Umberto Rosini",
+      "email": "rosini@agid.gov.it",
+      "url": "https://github.com/umbros"
+    },
+    "contributors": [
+      {
+        "name": "Simone Rescio",
+        "email": "info@simonerescio.it",
+        "url": "https://simonerescio.it"
+      },
+      {
+        "name": "Davide Porrovecchio",
+        "email": "davide.porrovecchio@agid.gov.it",
+        "url": "https://github.com/pdavide"
+      }
+    ],
+    "scripts": {
+      "preinstall": "node tasksConfig/check-node-version.js",
+      "security": "grunt retire",
+      "start": "grunt build && grunt serve & grunt watch ; fg",
+      "postinstall": "npm run security; npm start",
+      "lint": "grunt lint",
+      "test": "grunt test",
+      "coverage": "karma start tasksConfig/karma.config.js && grunt log-coverage",
+      "performance": "lighthouse $npm_package_localserver_url$npm_package_localserver_port/index.html --output-path=reports/lighthouse.html --view",
+      "precommit": "npm run lint",
+      "prepush": "npm test && npm run coverage"
+    },
+    "devDependencies": {
+      "axe-core": "^2.4.2",
+      "eslint-config-crockford": "^2.0.0",
+      "eslint-plugin-jasmine": "^2.9.1",
+      "grunt": "^1.0.1",
+      "grunt-contrib-jasmine": "1.1.0",
+      "grunt-contrib-uglify": "3.1.0",
+      "grunt-contrib-watch": "1.0.0",
+      "grunt-eslint": "^20.1.0",
+      "grunt-postcss": "^0.9.0",
+      "grunt-retire": "^1.0.7",
+      "grunt-serve": "git@github.com:srescio/grunt-serve.git#bump-deps-fix-security-warns",
+      "grunt-sass": "^2.1.0",
+      "grunt-string-replace": "^1.3.1",
+      "grunt-stylelint": "^0.9.0",
+      "husky": "^0.14.3",
+      "karma": "^1.7.1",
+      "karma-coverage": "^1.1.1",
+      "karma-jasmine": "^1.1.0",
+      "karma-phantomjs-launcher": "^1.0.4",
+      "lighthouse": "^2.7.0",
+      "load-grunt-tasks": "^3.5.2",
+      "node-sass": "^4.9.0",
+      "promise-polyfill": "^6.0.2",
+      "stylelint": "^8.2.0",
+      "stylelint-config-standard": "^17.0.0"
     }
-  ],
-  "scripts": {
-    "preinstall": "node tasksConfig/check-node-version.js",
-    "security": "grunt retire",
-    "start": "grunt build && grunt serve & grunt watch ; fg",
-    "postinstall": "npm run security; npm start",
-    "lint": "grunt lint",
-    "test": "grunt test",
-    "coverage": "karma start tasksConfig/karma.config.js && grunt log-coverage",
-    "performance": "lighthouse $npm_package_localserver_url$npm_package_localserver_port/index.html --output-path=reports/lighthouse.html --view",
-    "precommit": "npm run lint",
-    "prepush": "npm test && npm run coverage"
-  },
-  "devDependencies": {
-    "axe-core": "^2.4.2",
-    "eslint-config-crockford": "^2.0.0",
-    "eslint-plugin-jasmine": "^2.9.1",
-    "grunt": "^1.0.1",
-    "grunt-contrib-jasmine": "1.1.0",
-    "grunt-contrib-sass": "1.0.0",
-    "grunt-contrib-uglify": "3.1.0",
-    "grunt-contrib-watch": "1.0.0",
-    "grunt-eslint": "^20.1.0",
-    "grunt-postcss": "^0.9.0",
-    "grunt-retire": "^1.0.7",
-    "grunt-serve": "git@github.com:srescio/grunt-serve.git#bump-deps-fix-security-warns",
-    "grunt-string-replace": "^1.3.1",
-    "grunt-stylelint": "^0.9.0",
-    "husky": "^0.14.3",
-    "karma": "^1.7.1",
-    "karma-coverage": "^1.1.1",
-    "karma-jasmine": "^1.1.0",
-    "karma-phantomjs-launcher": "^1.0.4",
-    "lighthouse": "^2.7.0",
-    "load-grunt-tasks": "^3.5.2",
-    "promise-polyfill": "^6.0.2",
-    "stylelint": "^8.2.0",
-    "stylelint-config-standard": "^17.0.0"
   }
-}


### PR DESCRIPTION
I fogli di stile sono scritti in linguaggio SCSS e quindi viene utilizzato uno strumento per compilare questi file in CSS. Attualmente vengono utilizzato il task Grunt di compilazione "grunt-contrib-sass" che sfrutta il tool di compilazione scritto in Ruby. Questo implica la necessità di installare sia Ruby che SASS per Ruby. Essendo un progetto gestito con strumenti NPM, propongo di compilare i file con la libreria Node.js "node-sass" e quindi il task Grunt di compilazione "grunt-sass".
Inoltre nel Gruntfile.js, i target sono stati chiamati con i comuni nomi "dev" e "prod" invece di "development" e "production".